### PR TITLE
fix default select & add custom font-size

### DIFF
--- a/src/assets/scripts/editor.js
+++ b/src/assets/scripts/editor.js
@@ -10,12 +10,16 @@ var app = new Vue({
       currentEditorTheme: 'base16-light',
       editor: null,
       builtinFonts: [
-        { label: '衬线', value: 'serif', fonts: "Optima-Regular, Optima, PingFangSC-light, PingFangTC-light, 'PingFang SC', Cambria, Cochin, Georgia, Times, 'Times New Roman', serif"},
-        { label: '无衬线', value: 'sans-serif', fonts: "Roboto, Oxygen, Ubuntu, Cantarell, PingFangSC-light, PingFangTC-light, 'Open Sans', 'Helvetica Neue', sans-serif"}
+        { label: '衬线', value: "Optima-Regular, Optima, PingFangSC-light, PingFangTC-light, 'PingFang SC', Cambria, Cochin, Georgia, Times, 'Times New Roman', serif"},
+        { label: '无衬线', value: "Roboto, Oxygen, Ubuntu, Cantarell, PingFangSC-light, PingFangTC-light, 'Open Sans', 'Helvetica Neue', sans-serif"}
       ],
-      currentFont: {
-        label: '', value: ''
-      },
+      currentFont: "Optima-Regular, Optima, PingFangSC-light, PingFangTC-light, 'PingFang SC', Cambria, Cochin, Georgia, Times, 'Times New Roman', serif",
+      currentSize: '16px',
+      sizeOption: [
+        { label: '16px', value: '16px', desc: '默认' },
+        { label: '17px', value: '17px', desc: '正常' },
+        { label: '18px', value: '18px', desc: '稍大' }
+      ],
       aboutDialogVisible: false
     }
   },
@@ -31,10 +35,11 @@ var app = new Vue({
     this.editor.on("change", function(cm, change) {
       self.refresh()
     })
-    this.currentFont = this.builtinFonts[0]
+    // this.currentFont = this.builtinFonts[0],
     this.wxRenderer = new WxRenderer({
       theme: defaultTheme,
-      fonts: this.currentFont.fonts
+      fonts: this.currentFont,
+      size: this.currentSize
     })
     axios({
       method: 'get',
@@ -57,6 +62,12 @@ var app = new Vue({
     fontChanged: function (fonts) {
       this.wxRenderer.setOptions({
         fonts: fonts
+      })
+      this.refresh()
+    },
+    sizeChanged: function(size){
+      this.wxRenderer.setOptions({
+        size: size
       })
       this.refresh()
     },

--- a/src/assets/scripts/renderers/wx-renderer.js
+++ b/src/assets/scripts/renderers/wx-renderer.js
@@ -14,7 +14,8 @@ var WxRenderer = function (opts) {
   this.buildTheme = function (themeTpl) {
     var mapping = {}
     var base = COPY(themeTpl.BASE, {
-      'font-family': this.opts.fonts
+      'font-family': this.opts.fonts,
+      'font-size': this.opts.size
     })
     var base_block = COPY(base, {
       'margin': '20px 10px'

--- a/src/assets/scripts/themes/default.js
+++ b/src/assets/scripts/themes/default.js
@@ -2,8 +2,7 @@ var defaultTheme = {
   BASE: {
     'text-align': 'left',
     'color': '#3f3f3f',
-    'line-height': '1.5',
-    'font-size': '16px',
+    'line-height': '1.5'
   },
   BASE_BLOCK: {
     'margin': '20px 10px'

--- a/src/index.html
+++ b/src/index.html
@@ -39,12 +39,23 @@
         <el-form label-width="80px" size="mini" class="ctrl">
           <el-form-item label="Fonts">
             <el-select v-model="currentFont" size="mini" placeholder="选择字体" @change="fontChanged">
-              <el-option v-for="font in builtinFonts"  :style="{fontFamily: font.fonts}"
+              <el-option v-for="font in builtinFonts"  :style="{fontFamily: font.value}"
                 :key="font.value"
                 :label="font.label"
-                :value="font.fonts">
+                :value="font.value">
                 <span style="float: left">{{ font.label }}</span>
                 <span style="float: right; color: #8492a6; font-size: 13px" >Abc</span>
+              </el-option>
+            </el-select>
+          </el-form-item>
+          <el-form-item label="Font Size">
+            <el-select v-model="currentSize" size="mini" placeholder="选择段落字体大小" @change="sizeChanged">
+              <el-option v-for="size in sizeOption"
+                :key="size.value"
+                :label="size.label"
+                :value="size.value">
+                <span style="float: left">{{ size.label }}</span>
+                <span style="float: right; color: #8492a6; font-size: 13px" >{{ size.desc }}</span>
               </el-option>
             </el-select>
           </el-form-item>


### PR DESCRIPTION
### 1. 修复默认选择的 Bug
选项框没有默认值选择
![image](https://user-images.githubusercontent.com/5508125/56415684-ff6bab80-62c0-11e9-9081-36a93dd2113a.png)
修复默认值显示问题。
![image](https://user-images.githubusercontent.com/5508125/56415909-c41dac80-62c1-11e9-9fde-e2b11ded1ee7.png)

### 2. 添加字体大小的自定义功能
不知道什么时候开始，默认的 16px 字体大小，在微信公众号上看起来显得小了，而且微信公众号的默认字体大小也调整成了 17px，17px 大小的看起来就刚刚好。

所以，添加了字体大小的自定义，如下：
![image](https://user-images.githubusercontent.com/5508125/56416267-ec59db00-62c2-11e9-8576-f7a94a358e03.png)