### PR TITLE
修复在Safari浏览器中预览页面高度不为父元素100%的问题

### DIFF
--- a/src/assets/css/app.css
+++ b/src/assets/css/app.css
@@ -50,7 +50,7 @@ section {
   align-items: center;
   justify-content: center;
   display: flex;
-  height: 100%;
+  /* height: 100%; */
   overflow: scroll;
 }
 .main-section {


### PR DESCRIPTION
在 Safari 浏览器中会出现预览页面的高度大于视口高度的情况，如下图

![屏幕快照 2019-05-26 下午5 32 51](https://user-images.githubusercontent.com/26177348/58379915-9290b300-7fdc-11e9-91d8-6efdc1590b8e.png)

但是在 Chrome 浏览器中并没有这样的问题。

将 preview-wrapper 的样式中 height 一项移除，Safari 中出现的问题即可解决，并且不会影响 Chrome 。